### PR TITLE
feat(appstore): lane upload_metadata с созданием draft-версии

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ fastlane upload_external_testflight groups:"External Public Beta"
 
 # Отправка на рецензирование в App Store
 fastlane pass_to_review
+
+# Заливка ТОЛЬКО метаданных (без бинаря и скриншотов).
+# Если редактируемой версии в App Store Connect нет — создаёт draft-версию
+# и заполняет её текстами. Путь к метаданным берётся из Deliverfile.
+fastlane upload_metadata ver:2.0.0     # явная версия
+fastlane upload_metadata               # версия из ENV['APP_VERSION']
 ```
 
 ### Сборка и публикация macOS

--- a/fastlane/Fastfile_appstore
+++ b/fastlane/Fastfile_appstore
@@ -374,6 +374,89 @@ lane :update_metadata_year do |_options|
   SHELL
 end
 
+desc 'Заливает ТОЛЬКО метаданные в App Store Connect. Если редактируемой версии нет — создаёт draft-версию и заполняет её текстами.'
+# Использование:
+#   fastlane upload_metadata                 # версия берётся из ENV['APP_VERSION']
+#   fastlane upload_metadata ver:2.0.0       # явная версия
+#
+# Бинарь и скриншоты НЕ трогаются (skip_binary_upload / skip_screenshots).
+# Путь к метаданным берётся из Deliverfile (DELIVER_METADATA_PATH per pack).
+lane :upload_metadata do |options|
+  version_string = (options[:ver] || ENV['APP_VERSION']).to_s.strip
+  UI.user_error!('❌ Версия не указана. Передайте ver:X.Y.Z или установите APP_VERSION') if version_string.empty?
+
+  api_key = prepare_api_key_for_release_check
+  UI.user_error!('❌ Не удалось настроить App Store Connect API ключ. Установите APPSTORE_KEY_CONTENT или APPSTORE_KEY_PATH.') unless api_key
+
+  app_identifier = get_primary_app_identifier
+  UI.header("Заливка метаданных #{version_string} для #{app_identifier}")
+
+  # Гарантируем наличие редактируемой версии в App Store Connect.
+  # deliver не создаёт версию сам — без этого шага он падает с «No editable version».
+  ensure_editable_app_store_version(app_identifier: app_identifier, version_string: version_string)
+
+  deliver(
+    app_identifier: app_identifier,
+    app_version: version_string,
+    skip_binary_upload: true,
+    skip_screenshots: true,
+    skip_metadata: false,
+    skip_app_version_update: false,
+    overwrite_screenshots: false,
+    submit_for_review: false,
+    automatic_release: false,
+    force: true, # без интерактивной проверки HTML-превью
+    run_precheck_before_submit: false,
+    precheck_include_in_app_purchases: false
+  )
+
+  UI.success("✅ Метаданные версии #{version_string} загружены для #{app_identifier}")
+end
+
+# Находит редактируемую версию приложения в App Store Connect, при необходимости
+# создаёт новую draft-версию или переименовывает существующую draft под нужный номер.
+#
+# Редактируемой считается версия в состоянии PREPARE_FOR_SUBMISSION и подобных —
+# именно в неё deliver может писать метаданные. Если активная версия уже
+# READY_FOR_SALE / IN_REVIEW и т.п., создаётся новая draft с указанным номером.
+#
+# @param app_identifier [String] bundle id приложения
+# @param version_string [String] целевой marketing version (X.Y.Z)
+# @return [Spaceship::ConnectAPI::AppStoreVersion] редактируемая версия
+def ensure_editable_app_store_version(app_identifier:, version_string:)
+  require 'spaceship'
+
+  app = Spaceship::ConnectAPI::App.find(app_identifier)
+  UI.user_error!("❌ Приложение #{app_identifier} не найдено в App Store Connect") if app.nil?
+
+  platform = Spaceship::ConnectAPI::Platform::IOS
+
+  # Уже существует редактируемая (draft) версия?
+  edit_version = app.get_edit_app_store_version(platform: platform)
+
+  if edit_version
+    if edit_version.version_string.to_s == version_string
+      UI.success("Редактируемая версия #{version_string} уже существует — обновим её метаданные")
+      return edit_version
+    end
+
+    UI.message("Есть редактируемая версия #{edit_version.version_string}, меняю номер на #{version_string}")
+    edit_version.update(attributes: { versionString: version_string })
+    return edit_version
+  end
+
+  # Редактируемой версии нет — создаём новую draft.
+  UI.important("Редактируемой версии нет — создаю draft-версию #{version_string}")
+  created = Spaceship::ConnectAPI.post_app_store_version(
+    app_id: app.id,
+    attributes: { versionString: version_string, platform: platform }
+  )
+  UI.success("Создана draft-версия #{version_string}")
+  created
+rescue StandardError => e
+  UI.user_error!("❌ Не удалось подготовить редактируемую версию #{version_string}: #{e.message}")
+end
+
 desc 'Merge and delete an existing release branch'
 lane :merge_and_delete_release_branch do |_options|
   release_branch = git_branch


### PR DESCRIPTION
## Что

Новый lane `upload_metadata` — заливает в App Store Connect **только метаданные** (без бинаря и скриншотов).

- `lane :upload_metadata` — `deliver` со `skip_binary_upload: true`, `skip_screenshots: true`, `skip_metadata: false`. Путь к метаданным берётся из `Deliverfile` (`DELIVER_METADATA_PATH` per pack).
- `ensure_editable_app_store_version` — если в ASC нет редактируемой версии, создаёт **draft** через `Spaceship::ConnectAPI.post_app_store_version`; если draft есть с другим номером — переименовывает под нужный; если нужный номер уже редактируется — использует его.

## Зачем

`deliver` сам не создаёт версию и падает с «No editable version», если в ASC нет draft. Нужно было уметь заливать/обновлять тексты для версии, которой ещё нет — например, чтобы подготовить метаданные до сборки.

## Использование

```bash
fastlane upload_metadata ver:2.0.0    # явная версия
fastlane upload_metadata              # версия из ENV['APP_VERSION']
```

## На что смотреть ревьюеру

- API-ключ берётся через существующий `prepare_api_key_for_release_check` (он же настраивает Spaceship).
- Сигнатуры Spaceship выверены под fastlane 2.236.1 (`post_app_store_version(app_id:, attributes:)` — именованные аргументы).
- `ruby -c` проходит. **Боевой прогон против App Store Connect не выполнялся** — нужен реальный ASC-аккаунт; проверьте на одном паке перед использованием в CI.
